### PR TITLE
NeoVim terminal buffer colours

### DIFF
--- a/colors/NeoSolarized.vim
+++ b/colors/NeoSolarized.vim
@@ -831,6 +831,26 @@ exe "hi! NeomakeNeomakeInfoSign"    . s:fg_green    .s:bg_none   .s:fmt_none
 
 "}}}
 
+" NeoVim terminal buffer colours "{{{
+" ---------------------------------------------------------------------
+let g:terminal_color_0 = s:gui_base03
+let g:terminal_color_1 = s:gui_red
+let g:terminal_color_2 = s:gui_green
+let g:terminal_color_3 = s:gui_yellow
+let g:terminal_color_4 = s:gui_blue
+let g:terminal_color_5 = s:gui_magenta
+let g:terminal_color_6 = s:gui_cyan
+let g:terminal_color_7 = s:gui_base2
+let g:terminal_color_8 = s:gui_base02
+let g:terminal_color_9 = s:gui_orange
+let g:terminal_color_10 = s:gui_base01
+let g:terminal_color_11 = s:gui_base00
+let g:terminal_color_12 = s:gui_base0
+let g:terminal_color_13 = s:gui_violet
+let g:terminal_color_14 = s:gui_base1
+let g:terminal_color_15 = s:gui_base3
+"}}}
+
 " Utility autocommand "{{{
 " ---------------------------------------------------------------------
 " In cases where Solarized is initialized inside a terminal vim session and 


### PR DESCRIPTION
When using terminal buffers in a GUI app like VimR, the 16 standard Unix terminal colours will be used if your colour scheme does not set them.

Since these colours clash horribly with (Neo)Solarized, here's a patch to add them to this theme.

See https://github.com/qvacua/vimr/issues/310 for more info.