### PR TITLE
Highlight background of vertical split bar

### DIFF
--- a/colors/NeoSolarized.vim
+++ b/colors/NeoSolarized.vim
@@ -471,7 +471,7 @@ exe "hi! MoreMsg"        .s:fmt_none   .s:fg_blue   .s:bg_none
 exe "hi! ModeMsg"        .s:fmt_none   .s:fg_blue   .s:bg_none
 exe "hi! LineNr"         .s:fmt_none   .s:fg_base01 .s:bg_base02
 exe "hi! Question"       .s:fmt_bold   .s:fg_cyan   .s:bg_none
-exe "hi! VertSplit"      .s:fmt_none   .s:fg_base00 .s:bg_none
+exe "hi! VertSplit"      .s:fmt_none   .s:fg_base00 .s:bg_base00
 exe "hi! Title"          .s:fmt_bold   .s:fg_orange .s:bg_none
 exe "hi! VisualNOS"      .s:fmt_stnd   .s:fg_none   .s:bg_base02 .s:fmt_revbb
 exe "hi! WarningMsg"     .s:fmt_bold   .s:fg_red    .s:bg_none


### PR DESCRIPTION
Both Solarized and Flattened highlight the vertical split bar. If the user has set whitespace as the 'fillchars' the border would be invisible.

I don't know why the background of your scheme is empty, was that a deliberate design decision? I don't like the vertical dashes as a separator character, it looks too noisy to me and I prefer a solid coloured line instead.