### PR TITLE
Add option to control "bold as bright" behavior in terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Fork from [vim-colors-solarized](https://github.com/altercation/vim-colors-solar
     ```
 
 ## Installation
-- Manual install  
+- Manual install
 Move NeoSolarized.vim to your vim RunTimePath directory:
 
     ```bash
@@ -42,25 +42,31 @@ Some options of the original solarized theme were removed or renamed to avoid co
 Make sure to put configuration before the line `colorscheme NeoSolarized` in `init.vim` or `.vimrc`.
 
 ```vim
-" default value is "normal", Setting this option to "high" or "low" does use the 
-" same Solarized palette but simply shifts some values up or down in order to 
+" Default value is "normal", Setting this option to "high" or "low" does use the
+" same Solarized palette but simply shifts some values up or down in order to
 " expand or compress the tonal range displayed.
 let g:neosolarized_contrast = "normal"
 
-" Special characters such as trailing whitespace, tabs, newlines, when displayed 
-" using ":set list" can be set to one of three levels depending on your needs. 
+" Special characters such as trailing whitespace, tabs, newlines, when displayed
+" using ":set list" can be set to one of three levels depending on your needs.
 " Default value is "normal". Provide "high" and "low" options.
 let g:neosolarized_visibility = "normal"
 
-" I make vertSplitBar a transparent background color. If you like the origin solarized vertSplitBar
-" style more, set this value to 0.
+" I make vertSplitBar a transparent background color. If you like the origin
+" solarized vertSplitBar style more, set this value to 0.
 let g:neosolarized_vertSplitBgTrans = 1
 
-" If you wish to enable/disable NeoSolarized from displaying bold, underlined or italicized 
-" typefaces, simply assign 1 or 0 to the appropriate variable. Default values:  
+" If you wish to enable/disable NeoSolarized from displaying bold, underlined
+" or italicized" typefaces, simply assign 1 or 0 to the appropriate variable.
+" Default values:
 let g:neosolarized_bold = 1
 let g:neosolarized_underline = 1
 let g:neosolarized_italic = 0
+
+" Used to enable/disable "bold as bright" in Neovim terminal. If colors of bold
+" text output by commands like `ls` aren't what you expect, you might want to
+" try disabling this option. Default value:
+let g:neosolarized_termBoldAsBright = 1
 ```
 
 
@@ -98,7 +104,7 @@ awk 'BEGIN{
 }'
 ```
 ### Tmux
-You may need the same hack to make vim work well in tmux. Put these lines into your .vimrc:  
+You may need the same hack to make vim work well in tmux. Put these lines into your .vimrc:
 ```vim
 set t_8f=^[[38;2;%lu;%lu;%lum
 set t_8b=^[[48;2;%lu;%lu;%lum
@@ -108,7 +114,7 @@ The '^[' represent the escape char. You should press <kbd>Ctrl-v</kbd> + <kbd>Es
 check [issue](https://github.com/vim/vim/issues/993#issuecomment-241676971) and [issue](https://github.com/vim/vim/issues/981#issuecomment-242893385) for more information.
 
 
-neovim works perfect without this config.  If you encounter a color issue using tmux, make sure that:  
+neovim works perfect without this config.  If you encounter a color issue using tmux, make sure that:
 - you are using the latest version of tmux (v2.2)
 - your $TERM variable is set to "xterm-256color"
 - add the line below to your .tmux.conf file:

--- a/colors/NeoSolarized.vim
+++ b/colors/NeoSolarized.vim
@@ -2,7 +2,7 @@
 " Author:   iCyMind <icyminnd@gmail.com>
 " URL:      https://github.com/iCyMind/NeoSolarized
 " License:  MIT
-" Modified: Mon Sep 26 14:45:22 CST 2016
+" Modified: Wed Jun 12 18:41:42 PDT 2016
 
 " Usage "{{{
 "
@@ -19,13 +19,18 @@
 " ---------------------------------------------------------------------
 " OPTIONS:
 " ---------------------------------------------------------------------
-" g:neosolarized_contrast
-" g:neosolarized_visibility
-" g:neosolarized_diffmode
-" g:neosolarized_termtrans
+" Font styles:
 " g:neosolarized_bold
-" g:neosolarized_underline
 " g:neosolarized_italic
+" g:neosolarized_underline
+"
+" Appearance:
+" g:neosolarized_contrast
+" g:neosolarized_diffmode
+" g:neosolarized_termBoldAsBright
+" g:neosolarized_termtrans
+" g:neosolarized_vertSplitBgTrans
+" g:neosolarized_visibility
 "
 " ---------------------------------------------------------------------
 " INSTALLATION:
@@ -108,13 +113,17 @@
 " Default option values"{{{
 " ---------------------------------------------------------------------
 
-let g:neosolarized_contrast = get(g:, "neosolarized_contrast", "normal")
-let g:neosolarized_visibility = get(g:, "neosolarized_visibility", "normal")
-let g:neosolarized_diffmode = get(g:, "neosolarized_diffmode", "normal")
+" Font styles:
 let g:neosolarized_bold = get(g:, "neosolarized_bold", 1)
-let g:neosolarized_underline = get(g:, "neosolarized_underline", 1)
 let g:neosolarized_italic = get(g:, "neosolarized_italic", 0)
+let g:neosolarized_underline = get(g:, "neosolarized_underline", 1)
+
+" Appearance:
+let g:neosolarized_contrast = get(g:, "neosolarized_contrast", "normal")
+let g:neosolarized_diffmode = get(g:, "neosolarized_diffmode", "normal")
+let g:neosolarized_termBoldAsBright = get(g:, "neosolarized_termBoldAsBright", 1)
 let g:neosolarized_termtrans = get(g:, "neosolarized_termtrans", 0)
+let g:neosolarized_visibility = get(g:, "neosolarized_visibility", "normal")
 let g:neosolarized_vertSplitBgTrans = get(g:, "neosolarized_vertSplitBgTrans", 1)
 
 "}}}
@@ -869,14 +878,26 @@ let g:terminal_color_4 = s:gui_blue
 let g:terminal_color_5 = s:gui_magenta
 let g:terminal_color_6 = s:gui_cyan
 let g:terminal_color_7 = s:gui_base2
-let g:terminal_color_8 = s:gui_base02
-let g:terminal_color_9 = s:gui_orange
-let g:terminal_color_10 = s:gui_base01
-let g:terminal_color_11 = s:gui_base00
-let g:terminal_color_12 = s:gui_base0
-let g:terminal_color_13 = s:gui_violet
-let g:terminal_color_14 = s:gui_base1
-let g:terminal_color_15 = s:gui_base3
+
+if g:neosolarized_termBoldAsBright == 1
+  let g:terminal_color_8 = s:gui_base02
+  let g:terminal_color_9 = s:gui_orange
+  let g:terminal_color_10 = s:gui_base01
+  let g:terminal_color_11 = s:gui_base00
+  let g:terminal_color_12 = s:gui_base0
+  let g:terminal_color_13 = s:gui_violet
+  let g:terminal_color_14 = s:gui_base1
+  let g:terminal_color_15 = s:gui_base3
+else
+  let g:terminal_color_8 = g:terminal_color_0
+  let g:terminal_color_9 = g:terminal_color_1
+  let g:terminal_color_10 = g:terminal_color_2
+  let g:terminal_color_11 = g:terminal_color_3
+  let g:terminal_color_12 = g:terminal_color_4
+  let g:terminal_color_13 = g:terminal_color_5
+  let g:terminal_color_14 = g:terminal_color_6
+  let g:terminal_color_15 = g:terminal_color_7
+endif
 "}}}
 
 " Utility autocommand "{{{


### PR DESCRIPTION
Addresses #20.

I added a new option `g:neosolarized_termBoldAsBright`  which defaults to `1`. When set to `0`, `g:terminal_color_[8-15]` are set equal to `g:terminal_color_[0-7]`. (I also added info about this to the readme, and organized the options a little.)