### PR TITLE
Only add the "GUIEnter" autocommand if the GUI is not already active.

### DIFF
--- a/colors/NeoSolarized.vim
+++ b/colors/NeoSolarized.vim
@@ -917,7 +917,9 @@ endif
 " mode (detected with the script scope s:vmode variable). It also allows for
 " other potential terminal customizations that might make gui mode suboptimal.
 "
-autocmd GUIEnter * if (has('gui_running')) | exe "colorscheme " . g:colors_name | endif
+if !has('gui_running')
+  autocmd GUIEnter * if (has('gui_running')) | exe "colorscheme " . g:colors_name | endif
+endif
 "}}}
 
 " License "{{{


### PR DESCRIPTION
In case the GUI is already loaded, the autocommand is definitely not needed and may in some cases lead to overwriting manual changes to the highlighting groups.

For example, when using VimR, the GUIEnter autocommand is triggered _after_ the ColorScheme autocommands, which means that the colorscheme is reloaded. This prevents the user from overriding single highlight groups in .vimrc like `autocmd VimEnter,Colorscheme * :hi Cursor guibg=#ff0000`